### PR TITLE
Enable debug postfix for static library builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(IMGUI_SFML_CONFIG_DIR ${PROJECT_SOURCE_DIR} CACHE PATH "Path to a directory 
 set(IMGUI_SFML_CONFIG_NAME imconfig-SFML.h CACHE STRING "Name of a custom user ImGui config header")
 set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header will be installed")
 
+set(IMGUI_SFML_USE_DEBUG_POSTFIX_FOR_STATIC OFF CACHE BOOL "Use debug postfix for static library")
+
 # For FindImGui.cmake
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -83,6 +85,8 @@ endif()
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(ImGui-SFML PRIVATE IMGUI_SFML_SHARED_LIB)
   set_target_properties(ImGui-SFML PROPERTIES DEFINE_SYMBOL "IMGUI_SFML_EXPORTS")
+  set_target_properties(ImGui-SFML PROPERTIES DEBUG_POSTFIX "_d")
+elseif(IMGUI_SFML_USE_DEBUG_POSTFIX_FOR_STATIC)
   set_target_properties(ImGui-SFML PROPERTIES DEBUG_POSTFIX "_d")
 endif()
 if(IMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS)


### PR DESCRIPTION
This PR adds a CMAKE setting to enable the debug postfix when building the static library. This makes it easier to support multi-config generators.

In my particular case, I have a build system that builds (and installs) external dependencies to a local cache. If the dependency doesn't support the DEBUG_POSTFIX, then both Debug and Release builds end up generating the same `ImGui-SFML.lib` file. This causes downstream builds to fail when the build types don't match (usually a Debug build trying to link to a Release library).